### PR TITLE
Add Nix package definition with parinfer-rust dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,58 @@ Clojure-mcp-light provides two main tools:
    clj-paren-repair-claude-hook --help
    ```
 
+### Install via Nix
+
+If you use Nix, you can add this package to your development environment:
+
+1. Create a `shell.nix` in your project:
+
+   ```nix
+   { pkgs ? import <nixpkgs> {} }:
+
+   let
+     clojure-mcp-light = pkgs.callPackage (pkgs.fetchFromGitHub {
+       owner = "bhauman";
+       repo = "clojure-mcp-light";
+       rev = "v0.1.1";
+       sha256 = "120qc7xzqdrm70scvkd08lf1zf89v9fj4z7bqk00ngz33y86xagx";
+     }) {};
+   in
+   pkgs.mkShell {
+     buildInputs = [
+       clojure-mcp-light
+       pkgs.babashka
+       pkgs.clj-kondo
+     ];
+   }
+   ```
+
+   Or use it locally from a checkout:
+
+   ```nix
+   { pkgs ? import <nixpkgs> {} }:
+
+   let
+     clojure-mcp-light = pkgs.callPackage ./path/to/clojure-mcp-light/package.nix {};
+   in
+   pkgs.mkShell {
+     buildInputs = [
+       clojure-mcp-light
+       pkgs.babashka
+       pkgs.clj-kondo
+     ];
+   }
+   ```
+
+2. Enter the Nix shell:
+   ```bash
+   nix-shell
+   ```
+
+   This will make both `clj-paren-repair-claude-hook` and `clj-nrepl-eval` available in your PATH, along with parinfer-rust as a dependency.
+
+3. Configure Claude Code hooks as described in step 4 of the bbin installation above.
+
 ## Slash Commands
 
 > Experimental

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, babashka
+, parinfer-rust
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "clojure-mcp-light";
+  version = "0.1.0";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ babashka parinfer-rust ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Create installation directories
+    mkdir -p $out/share/${pname}
+    mkdir -p $out/bin
+
+    # Copy source files and bb.edn
+    cp -r src $out/share/${pname}/
+    cp bb.edn $out/share/${pname}/
+
+    # Create clj-paren-repair-claude-hook wrapper
+    makeWrapper ${babashka}/bin/bb $out/bin/clj-paren-repair-claude-hook \
+      --add-flags "-cp $out/share/${pname}/src:$out/share/${pname}/bb.edn" \
+      --add-flags "-m clojure-mcp-light.hook" \
+      --prefix PATH : ${lib.makeBinPath [ parinfer-rust ]}
+
+    # Create clj-nrepl-eval wrapper
+    makeWrapper ${babashka}/bin/bb $out/bin/clj-nrepl-eval \
+      --add-flags "-cp $out/share/${pname}/src:$out/share/${pname}/bb.edn" \
+      --add-flags "-m clojure-mcp-light.nrepl-eval" \
+      --prefix PATH : ${lib.makeBinPath [ parinfer-rust ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CLI tooling for Clojure development in Claude Code";
+    homepage = "https://github.com/bhauman/clojure-mcp-light";
+    license = licenses.mit; # Update if different
+    maintainers = [ ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Adds `package.nix` enabling installation via Nix without requiring bbin. Includes parinfer-rust as a build dependency and creates wrapped executables for both `clj-paren-repair-claude-hook` and `clj-nrepl-eval` commands.

Updates README.md with Nix installation section showing usage with both `fetchFromGitHub` and local checkout options.