### PR TITLE
Support Codex hooks via apply_patch dispatch (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Codex `apply_patch` hook support** - The hook now dispatches on Codex's `apply_patch` tool via the existing `process-hook` multimethod (no new binary or namespace). PreToolUse backs up the files a patch will touch; PostToolUse repairs them, restoring any unfixable file from its backup. Validated end-to-end against Codex 0.137.0.
+- **Auto-repair notice for `apply_patch`** - On a successful delimiter repair the PostToolUse hook tells the agent the on-disk file changed (re-read before further edits), since `apply_patch` matches on context lines and a silent change can desync the next patch.
+- **SessionStart stale temp-dir sweep** - A generic `SessionStart` hook (fires for both Claude Code and Codex) reaps `clojure-mcp-light` session dirs idle for 3+ days. This covers Codex, which has a `SessionStart` event but no `SessionEnd`. Staleness is judged by the newest mtime across the session tree, so an active session (and its persistent nREPL state) is never reaped; the current session is always protected.
+
 ## [0.2.2] - 2026-03-14
 
 This release fixes the PreToolUse Write hook so delimiter repairs are actually applied, adds ClojureDart (.cljd) file support, and updates documentation to recommend heredoc for code evaluation.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ errors before they hit the filesystem.
 
 > In my usage these Hooks have fixed 100% of the errors detected.
 
-**Note:** The intention is to create and release client-specific hook tools as other LLM clients add hook support. For example, when Gemini CLI adds hooks, a `clj-paren-repair-gemini-hook` tool will be made available.
+**Note:** This binary already works with [Codex](https://developers.openai.com/codex/hooks), which shares Claude Code's hook wire format — see [Use with Codex](#use-with-codex-apply_patch) below. As other LLM clients add hook support they'll be covered too; for example, when Gemini CLI adds hooks it can use the same approach.
 
 **Why hooks instead of MCP tools?**
 
@@ -299,6 +299,62 @@ Add to `~/.claude/settings.json`:
 **Write operations**: If delimiter errors are detected, the content is fixed via parinfer before writing. If unfixable, the write is blocked.
 
 **Edit operations**: A backup is created before the edit. After the edit, if delimiter errors exist, they're fixed automatically. If unfixable, the file is restored from backup.
+
+### Use with Codex (`apply_patch`)
+
+[Codex](https://developers.openai.com/codex/hooks) supports the same hook wire
+format as Claude Code, so the **same `clj-paren-repair-claude-hook` binary**
+works there too — no separate tool to install. The one difference: Codex makes
+all file edits through a single `apply_patch` tool (a patch document) rather
+than `Write`/`Edit`. The hook understands `apply_patch` and repairs every
+Clojure file a patch touches.
+
+Add to `~/.codex/hooks.json` (global) or `<repo>/.codex/hooks.json` (per
+project):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          { "type": "command", "command": "clj-paren-repair-claude-hook --cljfmt" }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^apply_patch$",
+        "hooks": [
+          { "type": "command", "command": "clj-paren-repair-claude-hook --cljfmt" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^apply_patch$",
+        "hooks": [
+          { "type": "command", "command": "clj-paren-repair-claude-hook --cljfmt" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**What each hook does:**
+
+- **PreToolUse `apply_patch`** backs up the files the patch will touch.
+- **PostToolUse `apply_patch`** repairs delimiter errors in the patched files. If a file can't be fixed it's restored from the backup and Codex is told why. On a *successful* repair Codex is notified that the file changed on disk (re-read before further edits) — `apply_patch` matches on context lines, so a silent change can desync the next patch.
+- **SessionStart** sweeps `clojure-mcp-light` temp dirs idle for 3+ days. Codex has no `SessionEnd` event, so cleanup runs at session start instead.
+
+**Codex-specific notes:**
+
+- **Trust the hooks.** Codex requires you to review and trust command hooks before they run — use `/hooks` in the TUI. Trust is keyed to the file's hash, so editing `hooks.json` requires re-trusting.
+- **Hooks run only in the interactive TUI**, not under `codex exec`.
+- **`SessionStart` fires when the session is configured** — i.e. after your first message, not at bare launch.
+- The `^apply_patch$` matcher scopes the hook to file edits. (`.*` also works but then the hook runs on every tool call, including shell commands.)
 
 ### Statistics Tracking
 

--- a/src/clojure_mcp_light/apply_patch.clj
+++ b/src/clojure_mcp_light/apply_patch.clj
@@ -1,0 +1,93 @@
+(ns clojure-mcp-light.apply-patch
+  "Parsing for Codex apply_patch commands.
+
+   Codex hooks share Claude Code's hook wire format, but Codex edits files
+   through a single `apply_patch` tool whose input is a patch document.
+   This namespace extracts the affected file operations from that document
+   so the hook can back up, repair, and revert the right files."
+  (:require [babashka.fs :as fs]
+            [clojure.java.io :as io]
+            [clojure.string :as string]))
+
+(def ^:private directive-prefixes
+  [["*** Update File: " :update]
+   ["*** Move to: "     :move-to]
+   ["*** Add File: "    :add]
+   ["*** Delete File: " :delete]])
+
+(defn- parse-line
+  [line]
+  (some (fn [[prefix kind]]
+          (when (string/starts-with? line prefix)
+            (let [path (string/trim (subs line (count prefix)))]
+              (when-not (string/blank? path)
+                {:directive kind :path path}))))
+        directive-prefixes))
+
+(defn- parse-ops
+  "Group parsed directives into ordered ops. An `:update` immediately
+   followed by `:move-to` is folded into a single `:move` op."
+  [directives]
+  (loop [ds directives
+         ops []]
+    (if-let [d (first ds)]
+      (case (:directive d)
+        :update
+        (if (= :move-to (:directive (second ds)))
+          (recur (drop 2 ds)
+                 (conj ops {:op :move :from (:path d) :to (:path (second ds))}))
+          (recur (rest ds) (conj ops {:op :update :path (:path d)})))
+        :add     (recur (rest ds) (conj ops {:op :add :path (:path d)}))
+        :delete  (recur (rest ds) (conj ops {:op :delete :path (:path d)}))
+        ;; A :move-to not preceded by :update has no meaning on its own
+        :move-to (recur (rest ds) ops))
+      ops)))
+
+(defn resolve-path
+  "Resolve an apply_patch file path against the Codex session cwd.
+   apply_patch paths are usually relative, unlike Claude's absolute file_path."
+  [cwd file-path]
+  (let [file (io/file file-path)]
+    (-> (if (.isAbsolute file)
+          file
+          (io/file (or cwd (System/getProperty "user.dir")) file-path))
+        fs/absolutize
+        fs/normalize
+        str)))
+
+(defn- resolve-op-paths
+  [cwd op]
+  (let [resolve* #(resolve-path cwd %)]
+    (cond-> op
+      (:path op) (update :path resolve*)
+      (:from op) (update :from resolve*)
+      (:to op)   (update :to resolve*))))
+
+(defn ops
+  "Parse a Codex apply_patch hook input into ops with paths resolved
+   against the session cwd. Op shapes:
+   {:op :update :path p}, {:op :add :path p}, {:op :delete :path p},
+   {:op :move :from a :to b}"
+  [{:keys [cwd tool_input]}]
+  (->> (string/split-lines (or (:command tool_input) ""))
+       (keep parse-line)
+       parse-ops
+       (mapv #(resolve-op-paths cwd %))))
+
+(defn op-source
+  "Pre-patch path that needs a backup to make the op revertible.
+   nil for :add (revert is deletion) and :delete (nothing to repair)."
+  [op]
+  (case (:op op)
+    :update (:path op)
+    :move   (:from op)
+    (:add :delete) nil))
+
+(defn op-target
+  "Post-patch path that should be repaired/formatted. nil for :delete."
+  [op]
+  (case (:op op)
+    :update (:path op)
+    :move   (:to op)
+    :add    (:path op)
+    :delete nil))

--- a/src/clojure_mcp_light/hook.clj
+++ b/src/clojure_mcp_light/hook.clj
@@ -556,6 +556,23 @@
       (timbre/error "  Unexpected error during cleanup:" (.getMessage e))
       nil)))
 
+(defmethod process-hook ["SessionStart" nil]
+  [{:keys [session_id]}]
+  (timbre/info "SessionStart: sweeping stale session dirs")
+  (try
+    (let [report (tmp/cleanup-stale-sessions! {:session-id session_id})]
+      (timbre/info "  Swept stale sessions under:" (:base report))
+      (timbre/info "  Deleted directories:" (:deleted report))
+      (timbre/info "  Kept directories:" (count (:kept report)))
+      (when (seq (:errors report))
+        (timbre/warn "  Errors during sweep:")
+        (doseq [{:keys [path error]} (:errors report)]
+          (timbre/warn "    " path "-" error)))
+      nil)
+    (catch Exception e
+      (timbre/error "  Unexpected error during stale-session sweep:" (.getMessage e))
+      nil)))
+
 (defn -main [& args]
   (let [options (handle-cli-args args)
         log-level (:log-level options)

--- a/src/clojure_mcp_light/hook.clj
+++ b/src/clojure_mcp_light/hook.clj
@@ -360,6 +360,16 @@
            (str ". Left in place (no backup or revert disabled): "
                 (string/join ", " kept))))))
 
+(defn- patch-repaired-context
+  "Non-blocking note telling the agent that delimiters were auto-repaired, so
+  the on-disk file no longer matches the patch it submitted. This matters for
+  apply_patch specifically, whose context-line matching breaks if the agent
+  patches from a stale memory of the file."
+  [repaired]
+  (str "Auto-repaired delimiters in "
+       (string/join ", " (map :file-path repaired))
+       "; on-disk content changed, re-read before further edits."))
+
 (defn- patch-applied?
   "Did the apply_patch tool actually modify files? Codex reports the result in
   tool_response as a STRING, e.g.
@@ -505,9 +515,11 @@
                              (assoc (fix-and-format-file! target *enable-cljfmt* "PostToolUse:apply_patch")
                                     :op op
                                     :file-path target)))
-              failures (remove :success results)]
+              failures (remove :success results)
+              repaired (filter :delimiter-fixed results)]
           (timbre/debug "PostApplyPatch: processed" (count results) "Clojure file(s)")
-          (when (seq failures)
+          (cond
+            (seq failures)
             (let [outcomes (mapv (fn [{:keys [op file-path]}]
                                    {:file-path file-path
                                     :outcome (revert-patch-op! op session_id)})
@@ -516,7 +528,14 @@
                :reason (patch-failure-reason failures outcomes)
                :hookSpecificOutput
                {:hookEventName "PostToolUse"
-                :additionalContext "There are delimiter errors in one or more Clojure files touched by apply_patch."}}))))
+                :additionalContext "There are delimiter errors in one or more Clojure files touched by apply_patch."}})
+
+            (seq repaired)
+            {:hookSpecificOutput
+             {:hookEventName "PostToolUse"
+              :additionalContext (patch-repaired-context repaired)}}
+
+            :else nil)))
       (finally
         (delete-patch-backups! ops session_id)))))
 

--- a/src/clojure_mcp_light/hook.clj
+++ b/src/clojure_mcp_light/hook.clj
@@ -10,6 +10,7 @@
             [clojure.string :as string]
             [clojure.java.io :as io]
             [clojure.tools.cli :refer [parse-opts]]
+            [clojure-mcp-light.apply-patch :as apply-patch]
             [clojure-mcp-light.delimiter-repair
              :refer [delimiter-error? fix-delimiters actual-delimiter-error?]]
             [clojure-mcp-light.stats :as stats]
@@ -285,6 +286,80 @@
         (finally
           (delete-backup backup-file))))))
 
+;; ============================================================================
+;; Codex apply_patch Support
+;; ============================================================================
+;;
+;; Codex hooks use the same wire format as Claude Code hooks, but Codex edits
+;; files through a single apply_patch tool. One patch can touch several files
+;; (update/add/delete/move), so backup, repair, and revert operate per-op.
+
+(defn- backup-patch-sources!
+  "Back up existing Clojure files that an apply_patch is about to modify."
+  [ops session-id]
+  (doseq [op ops
+          :let [path (apply-patch/op-source op)]
+          :when (and path (fs/exists? path) (clojure-file? path))]
+    (try
+      (let [backup (backup-file path session-id)]
+        (timbre/debug "  Created backup:" backup))
+      (catch Exception e
+        (timbre/debug "  Backup failed for" path ":" (.getMessage e))))))
+
+(defn- delete-patch-backups!
+  [ops session-id]
+  (doseq [op ops
+          :let [path (apply-patch/op-source op)]
+          :when path]
+    (delete-backup (tmp/backup-path {:session-id session-id} path))))
+
+(defn- revert-patch-op!
+  "Undo a failed apply_patch op from its backup. Returns one of:
+   :restored  - file content restored to its pre-patch state
+   :deleted   - newly added file removed
+   :no-backup - wanted to restore but no usable backup exists
+   :skipped   - revert disabled, or op has nothing to undo"
+  [op session-id]
+  (if-not *enable-revert*
+    :skipped
+    (case (:op op)
+      :update
+      (let [backup (tmp/backup-path {:session-id session-id} (:path op))]
+        (if (fs/exists? backup)
+          (do (restore-file (:path op) backup) :restored)
+          :no-backup))
+
+      :move
+      (let [backup (tmp/backup-path {:session-id session-id} (:from op))]
+        (if (fs/exists? backup)
+          (do (restore-file (:from op) backup)
+              (fs/delete-if-exists (:to op))
+              :restored)
+          :no-backup))
+
+      :add
+      (do (fs/delete-if-exists (:path op))
+          :deleted)
+
+      :delete :skipped)))
+
+(defn- patch-failure-reason
+  [failures outcomes]
+  (let [by-outcome (group-by :outcome outcomes)
+        paths-of (fn [k] (map :file-path (by-outcome k)))
+        restored (paths-of :restored)
+        deleted (paths-of :deleted)
+        kept (concat (paths-of :no-backup) (paths-of :skipped))]
+    (str "Delimiter errors could not be auto-fixed in "
+         (string/join ", " (map :file-path failures))
+         (when (seq restored)
+           (str ". Restored from backup: " (string/join ", " restored)))
+         (when (seq deleted)
+           (str ". Removed newly added files: " (string/join ", " deleted)))
+         (when (seq kept)
+           (str ". Left in place (no backup or revert disabled): "
+                (string/join ", " kept))))))
+
 (defmulti process-hook
   (fn [hook-input]
     [(:hook_event_name hook-input) (:tool_name hook-input)]))
@@ -397,6 +472,42 @@
     (process-hook (-> input
                       (assoc :tool_name "Edit")
                       (assoc-in [:tool_input :file_path] path)))))
+
+(defmethod process-hook ["PreToolUse" "apply_patch"]
+  [{:keys [session_id] :as input}]
+  (when *enable-revert*
+    (backup-patch-sources! (apply-patch/ops input) session_id))
+  nil)
+
+(defmethod process-hook ["PostToolUse" "apply_patch"]
+  [{:keys [session_id tool_response] :as input}]
+  (let [ops (apply-patch/ops input)
+        exit-code (:exit_code tool_response)
+        patch-applied? (or (nil? exit-code) (zero? exit-code))]
+    (try
+      (when patch-applied?
+        (let [results (vec (for [op ops
+                                 :let [target (apply-patch/op-target op)]
+                                 :when (and target
+                                            (fs/exists? target)
+                                            (clojure-file? target))]
+                             (assoc (fix-and-format-file! target *enable-cljfmt* "PostToolUse:apply_patch")
+                                    :op op
+                                    :file-path target)))
+              failures (remove :success results)]
+          (timbre/debug "PostApplyPatch: processed" (count results) "Clojure file(s)")
+          (when (seq failures)
+            (let [outcomes (mapv (fn [{:keys [op file-path]}]
+                                   {:file-path file-path
+                                    :outcome (revert-patch-op! op session_id)})
+                                 failures)]
+              {:decision "block"
+               :reason (patch-failure-reason failures outcomes)
+               :hookSpecificOutput
+               {:hookEventName "PostToolUse"
+                :additionalContext "There are delimiter errors in one or more Clojure files touched by apply_patch."}}))))
+      (finally
+        (delete-patch-backups! ops session_id)))))
 
 (defmethod process-hook ["SessionEnd" nil]
   [{:keys [session_id]}]

--- a/src/clojure_mcp_light/hook.clj
+++ b/src/clojure_mcp_light/hook.clj
@@ -360,6 +360,19 @@
            (str ". Left in place (no backup or revert disabled): "
                 (string/join ", " kept))))))
 
+(defn- patch-applied?
+  "Did the apply_patch tool actually modify files? Codex reports the result in
+  tool_response as a STRING, e.g.
+  \"Exit code: 0\\nWall time: 0.1 seconds\\nOutput:\\nSuccess. Updated ...\".
+  Treat the patch as applied unless we can see an explicit non-zero exit code.
+  Also accepts a map with :exit_code for robustness."
+  [tool-response]
+  (cond
+    (map? tool-response)    (let [ec (:exit_code tool-response)]
+                              (or (nil? ec) (zero? ec)))
+    (string? tool-response) (not (re-find #"(?im)^\s*exit code:\s*[1-9]" tool-response))
+    :else                   true))
+
 (defmulti process-hook
   (fn [hook-input]
     [(:hook_event_name hook-input) (:tool_name hook-input)]))
@@ -481,11 +494,9 @@
 
 (defmethod process-hook ["PostToolUse" "apply_patch"]
   [{:keys [session_id tool_response] :as input}]
-  (let [ops (apply-patch/ops input)
-        exit-code (:exit_code tool_response)
-        patch-applied? (or (nil? exit-code) (zero? exit-code))]
+  (let [ops (apply-patch/ops input)]
     (try
-      (when patch-applied?
+      (when (patch-applied? tool_response)
         (let [results (vec (for [op ops
                                  :let [target (apply-patch/op-target op)]
                                  :when (and target

--- a/src/clojure_mcp_light/tmp.clj
+++ b/src/clojure_mcp_light/tmp.clj
@@ -255,3 +255,70 @@
                    {:path sess-dir
                     :error (.getMessage e)})))))
     @results))
+
+(def ^:private default-max-session-age-ms
+  "Default staleness threshold for stale-session cleanup: 3 days."
+  (* 3 24 60 60 1000))
+
+(defn dir-last-activity-ms
+  "Most recent last-modified time (epoch ms) across a directory tree.
+
+  We look at the whole tree rather than the directory itself because nested
+  writes (backups, nREPL session files) bump child mtimes but not the parent's
+  creation-time mtime. Using the tree max means a session still in use is not
+  judged stale just because its top-level dir was created days ago."
+  [dir]
+  (->> (file-seq (fs/file dir))
+       (map #(.lastModified ^java.io.File %))
+       (reduce max 0)))
+
+(defn cleanup-stale-sessions!
+  "Sweep stale session directories under the clojure-mcp-light runtime base,
+  deleting any not modified within `:max-age-ms` (default 3 days).
+
+  Editor-agnostic: Claude Code can call this from SessionStart or SessionEnd, and
+  Codex (which has SessionStart but no SessionEnd) calls it from SessionStart.
+  Either way old sessions get reaped without relying on a clean session exit.
+
+  The current session's directories (resolved from :session-id / :gpid) are
+  always protected, so a live session is never reaped even if it has run a while.
+
+  Parameters:
+  - :session-id - Optional current session ID to protect
+  - :gpid       - Optional grandparent PID for fallback id calculation
+  - :max-age-ms - Staleness threshold in milliseconds (default 3 days)
+  - :now-ms     - Current time in ms (defaults to now; for testing)
+
+  Returns a cleanup report map:
+  - :base    - the scanned base directory
+  - :deleted - List of deleted directory paths
+  - :kept    - List of directories left in place (too recent or protected)
+  - :errors  - List of {:path path :error error-msg} maps for failures"
+  [{:keys [session-id gpid max-age-ms now-ms]}]
+  (let [base (fs/path (runtime-base-dir) "clojure-mcp-light")
+        max-age (or max-age-ms default-max-session-age-ms)
+        now (or now-ms (System/currentTimeMillis))
+        protected (set (map #(str (fs/file-name (session-root {:session-id %})))
+                            (get-possible-session-ids
+                             {:session-id session-id :gpid gpid})))
+        results (atom {:base (str base) :deleted [] :kept [] :errors []})]
+    (when (fs/exists? base)
+      (doseq [dir (fs/list-dir base)
+              :when (fs/directory? dir)]
+        (let [dir-str (str dir)]
+          (try
+            (cond
+              (contains? protected (str (fs/file-name dir)))
+              (swap! results update :kept conj dir-str)
+
+              (>= (- now (dir-last-activity-ms dir)) max-age)
+              (do (fs/delete-tree dir)
+                  (swap! results update :deleted conj dir-str))
+
+              :else
+              (swap! results update :kept conj dir-str))
+            (catch Exception e
+              (swap! results update :errors conj
+                     {:path dir-str
+                      :error (.getMessage e)}))))))
+    @results))

--- a/test/clojure_mcp_light/apply_patch_test.clj
+++ b/test/clojure_mcp_light/apply_patch_test.clj
@@ -1,0 +1,59 @@
+(ns clojure-mcp-light.apply-patch-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure-mcp-light.apply-patch :as apply-patch]))
+
+(deftest ops-test
+  (testing "parses an update and resolves relative paths against cwd"
+    (is (= [{:op :update :path "/proj/src/core.clj"}]
+           (apply-patch/ops
+            {:cwd "/proj"
+             :tool_input {:command (str "*** Begin Patch\n"
+                                        "*** Update File: src/core.clj\n"
+                                        "@@\n"
+                                        "-(def x 1)\n"
+                                        "+(def x 2)\n"
+                                        "*** End Patch\n")}}))))
+
+  (testing "leaves absolute paths alone"
+    (is (= [{:op :update :path "/elsewhere/core.clj"}]
+           (apply-patch/ops
+            {:cwd "/proj"
+             :tool_input {:command "*** Update File: /elsewhere/core.clj\n"}}))))
+
+  (testing "folds Update File + Move to into a single :move op"
+    (is (= [{:op :move :from "/proj/src/old.clj" :to "/proj/src/new.clj"}]
+           (apply-patch/ops
+            {:cwd "/proj"
+             :tool_input {:command (str "*** Begin Patch\n"
+                                        "*** Update File: src/old.clj\n"
+                                        "*** Move to: src/new.clj\n"
+                                        "*** End Patch\n")}}))))
+
+  (testing "parses add and delete ops"
+    (is (= [{:op :add :path "/proj/src/a.clj"}
+            {:op :delete :path "/proj/src/b.clj"}]
+           (apply-patch/ops
+            {:cwd "/proj"
+             :tool_input {:command (str "*** Begin Patch\n"
+                                        "*** Add File: src/a.clj\n"
+                                        "*** Delete File: src/b.clj\n"
+                                        "*** End Patch\n")}}))))
+
+  (testing "returns no ops for missing or empty commands"
+    (is (= [] (apply-patch/ops {:cwd "/proj" :tool_input {}})))
+    (is (= [] (apply-patch/ops {:cwd "/proj" :tool_input {:command ""}})))
+    (is (= [] (apply-patch/ops {:cwd "/proj"
+                                :tool_input {:command "*** Begin Patch\n*** End Patch\n"}})))))
+
+(deftest op-source-and-target-test
+  (testing "op-source is the pre-patch path needing backup"
+    (is (= "/a.clj" (apply-patch/op-source {:op :update :path "/a.clj"})))
+    (is (= "/a.clj" (apply-patch/op-source {:op :move :from "/a.clj" :to "/b.clj"})))
+    (is (nil? (apply-patch/op-source {:op :add :path "/a.clj"})))
+    (is (nil? (apply-patch/op-source {:op :delete :path "/a.clj"}))))
+
+  (testing "op-target is the post-patch path needing repair"
+    (is (= "/a.clj" (apply-patch/op-target {:op :update :path "/a.clj"})))
+    (is (= "/b.clj" (apply-patch/op-target {:op :move :from "/a.clj" :to "/b.clj"})))
+    (is (= "/a.clj" (apply-patch/op-target {:op :add :path "/a.clj"})))
+    (is (nil? (apply-patch/op-target {:op :delete :path "/a.clj"})))))

--- a/test/clojure_mcp_light/hook_test.clj
+++ b/test/clojure_mcp_light/hook_test.clj
@@ -173,7 +173,7 @@
   "Exit code: 1\nWall time: 0.1 seconds\nOutput:\nFailed to apply patch.\n")
 
 (deftest post-apply-patch-test
-  (testing "repairs Clojure files after apply_patch runs"
+  (testing "repairs Clojure files after apply_patch and reports the repair"
     (with-temp-project*
       (fn [dir]
         (let [file-path (str (fs/path dir "src/core.clj"))]
@@ -181,15 +181,38 @@
           (spit file-path "(def x 1" :encoding "UTF-8")
 
           (binding [hook/*enable-cljfmt* false]
+            (let [result (hook/process-hook
+                          {:session_id "post-apply-patch-test"
+                           :cwd dir
+                           :hook_event_name "PostToolUse"
+                           :tool_name "apply_patch"
+                           :tool_input {:command (apply-patch-command "src/core.clj")}
+                           :tool_response apply-patch-success-response})
+                  context (get-in result [:hookSpecificOutput :additionalContext])]
+              ;; File is repaired on disk ...
+              (is (= "(def x 1)" (slurp file-path :encoding "UTF-8")))
+              ;; ... and the agent is told (non-blocking) that the file changed
+              ;; underneath it, so apply_patch's context matching won't go stale.
+              (is (nil? (:decision result)))
+              (is (re-find #"Auto-repaired" context))
+              (is (re-find #"core\.clj" context)))))))))
+
+(deftest post-apply-patch-clean-is-silent-test
+  (testing "a clean apply_patch needing no repair returns nil (no context noise)"
+    (with-temp-project*
+      (fn [dir]
+        (let [file-path (str (fs/path dir "src/core.clj"))]
+          (fs/create-dirs (fs/parent file-path))
+          (spit file-path "(def x 1)" :encoding "UTF-8")
+
+          (binding [hook/*enable-cljfmt* false]
             (is (nil? (hook/process-hook
-                       {:session_id "post-apply-patch-test"
+                       {:session_id "post-apply-patch-clean-test"
                         :cwd dir
                         :hook_event_name "PostToolUse"
                         :tool_name "apply_patch"
                         :tool_input {:command (apply-patch-command "src/core.clj")}
-                        :tool_response apply-patch-success-response}))))
-
-          (is (= "(def x 1)" (slurp file-path :encoding "UTF-8"))))))))
+                        :tool_response apply-patch-success-response})))))))))
 
 (deftest post-apply-patch-skips-failed-patch-test
   (testing "a non-zero exit code in the tool_response string skips repair"

--- a/test/clojure_mcp_light/hook_test.clj
+++ b/test/clojure_mcp_light/hook_test.clj
@@ -1,6 +1,7 @@
 (ns clojure-mcp-light.hook-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure-mcp-light.hook :as hook]
+            [clojure-mcp-light.tmp :as tmp]
             [babashka.fs :as fs]))
 
 (deftest clojure-file?-test
@@ -98,3 +99,153 @@
                       :session_id "test-session"}
           result (hook/process-hook hook-input)]
       (is (nil? result)))))
+
+;; ============================================================================
+;; Codex apply_patch
+;; ============================================================================
+
+(defn- apply-patch-command
+  [file-path]
+  (str "*** Begin Patch\n"
+       "*** Update File: " file-path "\n"
+       "@@\n"
+       "-(def x 1)\n"
+       "+(def x 1\n"
+       "*** End Patch\n"))
+
+(defn- with-temp-project*
+  [f]
+  (let [dir (fs/create-temp-dir {:prefix "apply-patch-test-"})]
+    (try
+      (f (str dir))
+      (finally
+        (fs/delete-tree dir)))))
+
+(deftest pre-apply-patch-test
+  (testing "backs up existing Clojure files before apply_patch runs"
+    (with-temp-project*
+      (fn [dir]
+        (let [file-path (str (fs/path dir "src/core.clj"))
+              session-id "pre-apply-patch-test"
+              backup-path (tmp/backup-path {:session-id session-id} file-path)]
+          (fs/create-dirs (fs/parent file-path))
+          (spit file-path "(def x 1)" :encoding "UTF-8")
+
+          (try
+            (is (nil? (hook/process-hook
+                       {:session_id session-id
+                        :cwd dir
+                        :hook_event_name "PreToolUse"
+                        :tool_name "apply_patch"
+                        :tool_input {:command (apply-patch-command "src/core.clj")}})))
+            (is (fs/exists? backup-path))
+            (is (= "(def x 1)" (slurp backup-path :encoding "UTF-8")))
+            (finally
+              (hook/delete-backup backup-path))))))))
+
+(deftest pre-apply-patch-no-revert-test
+  (testing "does not back up files when revert is disabled"
+    (with-temp-project*
+      (fn [dir]
+        (let [file-path (str (fs/path dir "src/core.clj"))
+              session-id "pre-apply-patch-no-revert-test"
+              backup-path (tmp/backup-path {:session-id session-id} file-path)]
+          (fs/create-dirs (fs/parent file-path))
+          (spit file-path "(def x 1)" :encoding "UTF-8")
+
+          (binding [hook/*enable-revert* false]
+            (is (nil? (hook/process-hook
+                       {:session_id session-id
+                        :cwd dir
+                        :hook_event_name "PreToolUse"
+                        :tool_name "apply_patch"
+                        :tool_input {:command (apply-patch-command "src/core.clj")}}))))
+
+          (is (not (fs/exists? backup-path))))))))
+
+(deftest post-apply-patch-test
+  (testing "repairs Clojure files after apply_patch runs"
+    (with-temp-project*
+      (fn [dir]
+        (let [file-path (str (fs/path dir "src/core.clj"))]
+          (fs/create-dirs (fs/parent file-path))
+          (spit file-path "(def x 1" :encoding "UTF-8")
+
+          (binding [hook/*enable-cljfmt* false]
+            (is (nil? (hook/process-hook
+                       {:session_id "post-apply-patch-test"
+                        :cwd dir
+                        :hook_event_name "PostToolUse"
+                        :tool_name "apply_patch"
+                        :tool_input {:command (apply-patch-command "src/core.clj")}
+                        :tool_response {:exit_code 0}}))))
+
+          (is (= "(def x 1)" (slurp file-path :encoding "UTF-8"))))))))
+
+(deftest post-apply-patch-skips-failed-patch-test
+  (testing "non-zero apply_patch exit_code skips repair"
+    (with-temp-project*
+      (fn [dir]
+        (let [file-path (str (fs/path dir "src/core.clj"))]
+          (fs/create-dirs (fs/parent file-path))
+          (spit file-path "(def x 1" :encoding "UTF-8")
+
+          (binding [hook/*enable-cljfmt* false]
+            (is (nil? (hook/process-hook
+                       {:session_id "post-apply-patch-failed-test"
+                        :cwd dir
+                        :hook_event_name "PostToolUse"
+                        :tool_name "apply_patch"
+                        :tool_input {:command (apply-patch-command "src/core.clj")}
+                        :tool_response {:exit_code 1}}))))
+
+          ;; File content untouched because patch did not run.
+          (is (= "(def x 1" (slurp file-path :encoding "UTF-8"))))))))
+
+(deftest post-apply-patch-move-failure-test
+  (testing "unfixable delimiter errors after a move are reverted to the old path"
+    (with-temp-project*
+      (fn [dir]
+        (let [from (str (fs/path dir "src/old.clj"))
+              to (str (fs/path dir "src/new.clj"))
+              session-id "post-apply-patch-move-failure-test"
+              command (str "*** Begin Patch\n"
+                           "*** Update File: src/old.clj\n"
+                           "*** Move to: src/new.clj\n"
+                           "*** End Patch\n")]
+          (fs/create-dirs (fs/parent from))
+          (spit from "(def x 1)" :encoding "UTF-8")
+
+          ;; Pre-hook backs up the source.
+          (is (nil? (hook/process-hook
+                     {:session_id session-id
+                      :cwd dir
+                      :hook_event_name "PreToolUse"
+                      :tool_name "apply_patch"
+                      :tool_input {:command command}})))
+
+          ;; Simulate apply_patch performing a move and introducing an
+          ;; unfixable delimiter error in the new file.
+          (fs/delete-if-exists from)
+          (spit to "(def x 1" :encoding "UTF-8")
+
+          ;; Force fix-and-format-file! to fail so we hit the revert path.
+          (with-redefs [hook/fix-and-format-file!
+                        (fn [_ _ _]
+                          {:success false :delimiter-fixed false :formatted false
+                           :message "stub failure"})]
+            (let [response (hook/process-hook
+                            {:session_id session-id
+                             :cwd dir
+                             :hook_event_name "PostToolUse"
+                             :tool_name "apply_patch"
+                             :tool_input {:command command}
+                             :tool_response {:exit_code 0}})]
+              (is (= "block" (:decision response)))
+              (is (re-find #"Restored from backup" (:reason response)))))
+
+          ;; Old path is back with original content, new path is gone.
+          (is (fs/exists? from))
+          (is (= "(def x 1)" (slurp from :encoding "UTF-8")))
+          (is (not (fs/exists? to))))))))
+

--- a/test/clojure_mcp_light/hook_test.clj
+++ b/test/clojure_mcp_light/hook_test.clj
@@ -163,6 +163,15 @@
 
           (is (not (fs/exists? backup-path))))))))
 
+;; Codex reports the apply_patch result as a plain string in :tool_response
+;; (verified against a live Codex 0.137.0 run), not a map. These cover both the
+;; success and explicit-failure string shapes.
+(def ^:private apply-patch-success-response
+  "Exit code: 0\nWall time: 0.1 seconds\nOutput:\nSuccess. Updated the following files:\nM src/core.clj\n")
+
+(def ^:private apply-patch-failure-response
+  "Exit code: 1\nWall time: 0.1 seconds\nOutput:\nFailed to apply patch.\n")
+
 (deftest post-apply-patch-test
   (testing "repairs Clojure files after apply_patch runs"
     (with-temp-project*
@@ -178,12 +187,12 @@
                         :hook_event_name "PostToolUse"
                         :tool_name "apply_patch"
                         :tool_input {:command (apply-patch-command "src/core.clj")}
-                        :tool_response {:exit_code 0}}))))
+                        :tool_response apply-patch-success-response}))))
 
           (is (= "(def x 1)" (slurp file-path :encoding "UTF-8"))))))))
 
 (deftest post-apply-patch-skips-failed-patch-test
-  (testing "non-zero apply_patch exit_code skips repair"
+  (testing "a non-zero exit code in the tool_response string skips repair"
     (with-temp-project*
       (fn [dir]
         (let [file-path (str (fs/path dir "src/core.clj"))]
@@ -197,7 +206,7 @@
                         :hook_event_name "PostToolUse"
                         :tool_name "apply_patch"
                         :tool_input {:command (apply-patch-command "src/core.clj")}
-                        :tool_response {:exit_code 1}}))))
+                        :tool_response apply-patch-failure-response}))))
 
           ;; File content untouched because patch did not run.
           (is (= "(def x 1" (slurp file-path :encoding "UTF-8"))))))))

--- a/test/clojure_mcp_light/tmp_test.clj
+++ b/test/clojure_mcp_light/tmp_test.clj
@@ -329,3 +329,60 @@
       (is (fs/exists? nrepl))
       (is (fs/directory? backups))
       (is (fs/directory? nrepl)))))
+
+;; ============================================================================
+;; Stale Session Sweep
+;; ============================================================================
+
+(deftest cleanup-stale-sessions!-test
+  (testing "deletes stale dirs, keeps recent ones, and protects the live session"
+    (let [base-parent (fs/create-temp-dir {:prefix "cml-sweep-"})
+          base (fs/path base-parent "clojure-mcp-light")
+          day-ms (* 24 60 60 1000)
+          now 1700000000000]
+      (try
+        (with-redefs [tmp/runtime-base-dir (constantly (str base-parent))]
+          (fs/create-dirs base)
+          (let [stale (fs/create-dirs (fs/path base "stale-proj-aaa"))
+                fresh (fs/create-dirs (fs/path base "fresh-proj-bbb"))
+                live-name (str (fs/file-name (tmp/session-root {:session-id "live-sess"})))
+                live (fs/create-dirs (fs/path base live-name))
+                stale-file (fs/path stale "backups" "x.edn")
+                old (- now (* 10 day-ms))]
+            (fs/create-dirs (fs/parent stale-file))
+            (spit (str stale-file) "{}")
+            ;; stale and live are 10 days old throughout their trees; fresh is "now".
+            ;; Back-date nested files too, since staleness is judged by the
+            ;; newest mtime in the whole tree.
+            (fs/set-last-modified-time stale-file old)
+            (fs/set-last-modified-time (fs/path stale "backups") old)
+            (fs/set-last-modified-time stale old)
+            (fs/set-last-modified-time live old)
+            (fs/set-last-modified-time fresh now)
+
+            (let [report (tmp/cleanup-stale-sessions! {:session-id "live-sess"
+                                                       :max-age-ms (* 3 day-ms)
+                                                       :now-ms now})]
+              ;; Old, unprotected session is gone (whole tree, including files).
+              (is (not (fs/exists? stale)))
+              ;; Recent session survives.
+              (is (fs/exists? fresh))
+              ;; Live session is protected even though it is old.
+              (is (fs/exists? live))
+              (is (some #(str/ends-with? % "stale-proj-aaa") (:deleted report)))
+              (is (some #(str/ends-with? % live-name) (:kept report)))
+              (is (some #(str/ends-with? % "fresh-proj-bbb") (:kept report)))
+              (is (empty? (:errors report))))))
+        (finally
+          (fs/delete-tree base-parent)))))
+
+  (testing "no base directory yields an empty report without error"
+    (let [base-parent (fs/create-temp-dir {:prefix "cml-sweep-empty-"})]
+      (try
+        (with-redefs [tmp/runtime-base-dir (constantly (str base-parent))]
+          (let [report (tmp/cleanup-stale-sessions! {:session-id "x"})]
+            (is (= [] (:deleted report)))
+            (is (= [] (:kept report)))
+            (is (= [] (:errors report)))))
+        (finally
+          (fs/delete-tree base-parent))))))


### PR DESCRIPTION
## Summary

Adds Codex CLI support to `clj-paren-repair-claude-hook` by teaching it about
Codex's `apply_patch` tool. No new binary, no new namespace — Codex shares
Claude Code's hook wire format, so this is two new methods on the existing
`process-hook` multimethod plus a small parser for the patch document.

Closes #21. This is an alternative to #25, which took a separate
namespace/binary approach; everything here rides the existing dispatch so
Claude and Codex stay on one code path.

Credit to @danielcompton, who started this work and did the original Codex
hooks investigation in #25 — this PR builds directly on that.

## What it does

Codex makes every file edit through a single `apply_patch` tool whose
`tool_input.command` is a patch document (`*** Update/Add/Delete File:`,
`*** Move to:`). Three hook behaviors:

- **PreToolUse `apply_patch`** — parses the patch, resolves each path against
  the session `cwd`, and backs up the files it will touch.
- **PostToolUse `apply_patch`** — repairs delimiter errors in the patched
  files. Unfixable files are restored from backup and Codex is told why. On a
  *successful* repair Codex is notified that the file changed on disk
  (re-read before further edits), because `apply_patch` matches on context
  lines and a silent change would desync the next patch.
- **SessionStart** — a generic sweep (fires for both Claude Code and Codex)
  that reaps `clojure-mcp-light` temp dirs idle for 3+ days. Codex has no
  `SessionEnd`, so cleanup happens at session start. Staleness uses the newest
  mtime across the session tree, so an active session's persistent nREPL state
  is never reaped; the current session is always protected.

## Validated live against Codex 0.137.0

This was built and verified against a real Codex install, which corrected two
assumptions a spec-only implementation would have gotten wrong:

- **`tool_response` is a plain string** (`"Exit code: 0\n…Success…"`), not a
  map with `:exit_code`. The "skip repair on failed patch" guard now parses
  the string form.
- **Paths arrive both relative and absolute** depending on context; both are
  resolved against `cwd`.
- **`SessionStart` fires when the session is configured** — after the first
  message, not at bare launch — and **hooks run only in the interactive TUI**,
  not under `codex exec`. Documented as caveats.

The repair path was confirmed end-to-end: Codex wrote an unbalanced form via
`apply_patch`, the hook repaired it on disk, and Codex received the
auto-repair notice.

## Changes

- `src/clojure_mcp_light/apply_patch.clj` (new) — pure parser: patch document →
  ops with cwd-resolved paths (`:update`/`:add`/`:delete`/`:move`).
- `src/clojure_mcp_light/hook.clj` — `["PreToolUse" "apply_patch"]`,
  `["PostToolUse" "apply_patch"]`, and `["SessionStart" nil]` methods + helpers.
- `src/clojure_mcp_light/tmp.clj` — `cleanup-stale-sessions!` (age-based,
  tree-mtime, protects current session).
- README "Use with Codex" section + CHANGELOG.
- Tests for the parser, both apply_patch hooks (incl. real Codex
  `tool_response` strings and the revert path), and the sweep.

## Testing

`bb test` — 65 tests / 438 assertions, 0 failures. (One pre-existing error,
`parinfer-repair-test`, requires `parinfer-rust` on PATH and is unrelated.)
`clj-kondo` clean.
